### PR TITLE
Messages, hide/show nav, and css

### DIFF
--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -55,6 +55,8 @@ const addHandlers = () => {
   $('#change-password').on('submit', onChangePassword)
   $('#sign-out').on('submit', onSignOut)
   // $('#button').on('submit', addPlaylist)
+  $('.playlist-box').hide()
+  $('.sign-in-show').hide()
 }
 
 module.exports = {

--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -2,37 +2,40 @@
 const store = require('../store.js')
 
 const signUpSuccess = (data) => {
-  // $('#signUpModal').modal('hide')
-  $('.playlist-box').hide()
+  // $('.playlist-box').hide()
   $('input').val('')
+  $('#signUpModal').modal('hide')
+  $('.message').text('Signed up!')
 }
 
 const signUpFailure = () => {
-  $('.message').text('Sign up failed!')
-  $('.playlist-box').hide()
-  $('#signUpModal').modal('hide')
+  // $('.playlist-box').hide()
   $('input').val('')
+  $('#signUpModal').modal('hide')
+  $('.message').text('Sign up failed!')
 }
 
 // add shows where applicable
 const signInSuccess = (data) => {
-  $('.message').text('Create your playlist!')
-  $('.playlist-box').show()
-  $('#signInModal').modal('hide')
   $('input').val('')
   store.user = data.user
+  $('#signInModal').modal('hide')
+  $('.playlist-box').show()
+  $('.sign-in-show').show()
+  $('.sign-out-show').hide()
+  $('.message').text('Create your playlist!')
 }
 
 const signInFailure = () => {
-  $('.message').text('Sign in failed!')
-  $('#signInModal').modal('hide')
   $('input').val('')
+  $('#signInModal').modal('hide')
+  $('.message').text('Sign in failed!')
 }
 
 const changePasswordSuccess = (data) => {
-  $('.message').text('Password Successfully Changed!')
-  $('#changePasswordModal').modal('hide')
   $('input').val('')
+  $('#changePasswordModal').modal('hide')
+  $('.message').text('Password Successfully Changed!')
 }
 
 //   // store the user object as per below
@@ -50,10 +53,13 @@ const signOutSuccess = (data) => {
   $('#signOutModal').modal('hide')
   // store the user with a value of null as per below
   store.user = null
+  $('.playlist-box').hide()
+  $('.sign-in-show').hide()
+  $('.sign-out-show').show()
 }
 
 const signOutFailure = () => {
-  $('.message').text('Sign out faulire!')
+  $('.message').text('Sign out failure!')
   $('#signOutModal').modal('hide')
 }
 

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -93,3 +93,9 @@ input {
 //   padding: 50px 0;
 //   text-align: center;
 // }
+
+.vibes-description-box {
+  padding: 20px;
+  // margin: 0px;
+  background-color:rgba(100,100,100,0.3)
+}

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
     </div>
   </div>
 
-  <!-- Change Passwrord Modal -->
+  <!-- Change Password Modal -->
   <div id="changePasswordModal" class="modal fade" role="dialog">
     <div class="modal-dialog">
 
@@ -122,20 +122,23 @@
     </div>
   </div>
 
-  <h1>Example</h1>
+  <h3 class="message"></h3>
+  <div class="vibes-description-box">
+    <h2>Create Playlists Inspired By Your Moods - Your Vibes.</h2>
 
-  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
-    dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <h4>Vibes lets users create customized playlists from their favorite music tracks on Spotify. Users can create a unique name for their playlist, then they can customize the playlists they’ve created by adding their favorite song tracks to the playlists.</h4>
+  </div>
 
 
-  <h1>Playlist CRUD</h1>
   <div class="playlist-box sign-in-show">
+
+    <h1>Playlist Actions</h1>
     <!-- <form class='user-playlists'>
       <button type="submit" class="btn btn-default">Get all Playlists</button>
     </form> -->
     <div>
 
-<!-- If all else fails, use the form below for CREATEing a playlist -->
+      <!-- If all else fails, use the form below for CREATEing a playlist -->
       <h2>Give Your Playlist a Name</h2>
       <form id="new-playlist">
         <fieldset>
@@ -162,7 +165,7 @@
         <button type="submit" class="btn btn-default snip1564">Get Playlist</button>
       </form>
 
-<div id='handlebars-content'></div>
+      <div id='handlebars-content'></div>
 
       <h2>Update A Playlist</h2>
       <form class='playlists' id='playlist-update'>


### PR DESCRIPTION
add css for background of app description (transparent dark background)
hide/show for sign-up, sign-in, change-pw, and sign-out so that when a
user is not signed up or signed in or signed out, they are not able to
see the Playlist CRUD action area, and when a user is signed in
successfully, they are able to see the Playlist CRUD action area.
User facing auth messages updated.